### PR TITLE
Runs only the build task if no task args passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,23 +48,23 @@ const skeletorCli = () => {
 				logToConsole(errors.taskNotFound.replace('[taskName]', taskArgs[0]));
 			}
 		}
-	}
+	};
 
 	const isVersionCheck = () => {
 		return taskArgs.includes('version') || args.v;
-	}
+	};
 
 	const hasInvalidConfig = () => {
 		return !config.tasks || config.tasks.length === 0;
-	}
+	};
 
 	const hasTooManyTaskArgs = () => {
 		return taskArgs.length > 1;
-	}
+	};
 
 	const hasTooManySubTaskArgs = () => {
 		return subTaskArgs.only.length > 0 && subTaskArgs.except.length > 0
-	}
+	};
 
 	const runTasks = (filteredTasks) => {
 		filteredTasks.forEach(task => {
@@ -72,26 +72,26 @@ const skeletorCli = () => {
 				subTasksToInclude: filterSubTasks(task)
 			});
 		});
-	}
+	};
 
 	const filterTasks = () => {
 		if (taskArgs.length > 0) {
 			const filteredTasks = config.tasks.filter(task => task.name === taskArgs[0]);
 			return filteredTasks.length > 0 ? filteredTasks : null;
-		} else {
-			return config.tasks;
 		}
-	}
+		const buildTask = config.tasks.filter(task => task.name === 'build');
+		return buildTask && buildTask.length > 0 ? buildTask : null;
+	};
 
 	const filterSubTasks = (task) => {
 		if (subTaskArgs.only.length > 0) {
 			return filterSubTasksByMethod(task, 'only');
-		} else if (subTaskArgs.except.length > 0) {
-			return filterSubTasksByMethod(task, 'except');
-		} else {
-			return task.subTasks.map(subTask => subTask.name);
 		}
-	}
+		if (subTaskArgs.except.length > 0) {
+			return filterSubTasksByMethod(task, 'except');
+		}
+		return task.subTasks.map(subTask => subTask.name);
+	};
 
 	const filterSubTasksByMethod = (task, method) => {
 		return task.subTasks.reduce((accumulator, subTask) => {
@@ -107,18 +107,18 @@ const skeletorCli = () => {
 			}
 			return accumulator;
 		}, []);
-	}
+	};
 
 	const getSubTaskArgs = () => {
 		return {
 			only: args.only && args.only.length > 0 ? args.only.split(',') : [],
 			except: args.except && args.except.length > 0 ? args.except.split(',') : []
 		};
-	}
+	};
 
 	const logToConsole = (msg, prefix = errors.prefix, method = 'log') => {
 		console[method](`${prefix}${msg}`);
-	}
+	};
 
 	init();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/cli",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "The command line interface for Skeletor",
     "repository": "https://github.com/deg-skeletor/skeletor-cli.git",
     "main": "index.js",
@@ -21,7 +21,7 @@
     "dependencies": {
         "minimist": "^1.2.0",
         "inquirer": "^5.1.0",
-        "@deg-skeletor/core": "^1.0.0"
+        "@deg-skeletor/core": "^1.1.0"
     },
     "devDependencies": {
         "eslint": "^4.19.1",


### PR DESCRIPTION
Before, runnin `skel` with no task arguments would run every task (build, export, watch, serve, etc.), which was no bueno. Now it will only run the build task and its associated subtasks.