### PR TITLE
 Added support for "isDefaultTask" config property and fallback task

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ const skeletorCli = () => {
 				return logToConsole(errors.tooManySubTasks);
 			}
 			const filteredTask = filterTasks();
-			console.log(filteredTask);
 			if (filteredTask) {
 				runTask(filteredTask);
 			} else {

--- a/index.js
+++ b/index.js
@@ -80,15 +80,15 @@ const skeletorCli = () => {
 	};
 
 	const filterTasks = () => {
-		let filteredTasks;
+		let filteredTask;
 		if (taskArgs.length > 0) {
-			const tasksMatchingArgs = config.tasks.find(task => task.name === taskArgs[0]);
-			filteredTasks = tasksMatchingArgs || null;
+			const taskMatchingArgs = config.tasks.find(task => task.name === taskArgs[0]);
+			filteredTask = taskMatchingArgs || null;
 		} else {
 			const defaultTask = config.tasks.find(task => task.isDefaultTask === true);
-			filteredTasks = defaultTask || config.tasks[0];
+			filteredTask = defaultTask || config.tasks[0];
 		}
-		return filteredTasks;
+		return filteredTask;
 	};
 
 	const filterSubTasks = (task) => {

--- a/index.js
+++ b/index.js
@@ -48,9 +48,10 @@ const skeletorCli = () => {
 			if (hasTooManySubTaskArgs()) {
 				return logToConsole(errors.tooManySubTasks);
 			}
-			const filteredTasks = filterTasks();
-			if (filteredTasks) {
-				runTasks(filteredTasks);
+			const filteredTask = filterTasks();
+			console.log(filteredTask);
+			if (filteredTask) {
+				runTask(filteredTask);
 			} else {
 				logToConsole(errors.taskNotFound.replace('[taskName]', taskArgs[0]));
 			}
@@ -73,20 +74,22 @@ const skeletorCli = () => {
 		return subTaskArgs.only.length > 0 && subTaskArgs.except.length > 0
 	};
 
-	const runTasks = (filteredTasks) => {
-		filteredTasks.forEach(task => {
-			skelCore.runTask(task.name, {
-				subTasksToInclude: filterSubTasks(task)
-			});
+	const runTask = task => {
+		skelCore.runTask(task.name, {
+			subTasksToInclude: filterSubTasks(task)
 		});
 	};
 
 	const filterTasks = () => {
+		let filteredTasks;
 		if (taskArgs.length > 0) {
-			const filteredTasks = config.tasks.filter(task => task.name === taskArgs[0]);
-			return filteredTasks.length > 0 ? filteredTasks : null;
+			const tasksMatchingArgs = config.tasks.find(task => task.name === taskArgs[0]);
+			filteredTasks = tasksMatchingArgs || null;
+		} else {
+			const defaultTask = config.tasks.find(task => task.isDefaultTask === true);
+			filteredTasks = defaultTask || config.tasks[0];
 		}
-		return config.tasks;
+		return filteredTasks;
 	};
 
 	const filterSubTasks = (task) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/cli",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -292,6 +292,16 @@
                         "chardet": "^0.7.0",
                         "iconv-lite": "^0.4.24",
                         "tmp": "^0.0.33"
+                    }
+                },
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "iconv-lite": {
@@ -659,21 +669,10 @@
             }
         },
         "acorn-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-            "dev": true,
-            "requires": {
-                "acorn": "^3.0.4"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                    "dev": true
-                }
-            }
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+            "dev": true
         },
         "acorn-walk": {
             "version": "6.1.1",
@@ -682,27 +681,22 @@
             "dev": true
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
-        },
-        "ajv-keywords": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-            "dev": true
         },
         "ansi-escapes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-            "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+            "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+            "dev": true
         },
         "ansi-regex": {
             "version": "3.0.0",
@@ -760,31 +754,10 @@
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
-        "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
-            "requires": {
-                "array-uniq": "^1.0.1"
-            }
-        },
-        "array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-            "dev": true
-        },
-        "arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
             "dev": true
         },
         "asn1": {
@@ -843,59 +816,6 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "babel-jest": {
             "version": "24.8.0",
@@ -1117,23 +1037,6 @@
                 "unset-value": "^1.0.0"
             }
         },
-        "caller-path": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-            "dev": true,
-            "requires": {
-                "callsites": "^0.2.0"
-            },
-            "dependencies": {
-                "callsites": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                    "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                    "dev": true
-                }
-            }
-        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1165,6 +1068,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
             "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -1172,9 +1076,9 @@
             }
         },
         "chardet": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "child-process-promise": {
             "version": "2.2.1",
@@ -1201,12 +1105,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
-        },
-        "circular-json": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
             "dev": true
         },
         "class-utils": {
@@ -1318,18 +1216,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
         "convert-source-map": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1352,12 +1238,14 @@
             "dev": true
         },
         "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
             }
@@ -1486,21 +1374,6 @@
                 }
             }
         },
-        "del": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-            "dev": true,
-            "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
-            }
-        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1520,9 +1393,9 @@
             "dev": true
         },
         "doctrine": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2"
@@ -1621,98 +1494,111 @@
             }
         },
         "eslint": {
-            "version": "4.19.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-            "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+            "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "babel-code-frame": "^6.22.0",
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.10.0",
                 "chalk": "^2.1.0",
-                "concat-stream": "^1.6.0",
-                "cross-spawn": "^5.1.0",
-                "debug": "^3.1.0",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^3.7.1",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^1.3.1",
                 "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.4",
-                "esquery": "^1.0.0",
+                "espree": "^6.0.0",
+                "esquery": "^1.0.1",
                 "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
+                "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.0.1",
-                "ignore": "^3.3.3",
+                "glob-parent": "^5.0.0",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
-                "inquirer": "^3.0.6",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.9.1",
+                "inquirer": "^6.4.1",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.3.0",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.2",
+                "lodash": "^4.17.14",
+                "minimatch": "^3.0.4",
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
                 "progress": "^2.0.0",
-                "regexpp": "^1.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.3.0",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "~2.0.1",
-                "table": "4.0.2",
-                "text-table": "~0.2.0"
+                "regexpp": "^2.0.1",
+                "semver": "^6.1.2",
+                "strip-ansi": "^5.2.0",
+                "strip-json-comments": "^3.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "globals": {
-                    "version": "11.5.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-                    "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "inquirer": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-                    "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "^3.0.0",
-                        "chalk": "^2.0.0",
-                        "cli-cursor": "^2.1.0",
-                        "cli-width": "^2.0.0",
-                        "external-editor": "^2.0.4",
-                        "figures": "^2.0.0",
-                        "lodash": "^4.3.0",
-                        "mute-stream": "0.0.7",
-                        "run-async": "^2.2.0",
-                        "rx-lite": "^4.0.8",
-                        "rx-lite-aggregates": "^4.0.8",
-                        "string-width": "^2.1.0",
-                        "strip-ansi": "^4.0.0",
-                        "through": "^2.3.6"
+                        "ms": "^2.1.1"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
         },
         "eslint-scope": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+            "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+            "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.0.0"
             }
         },
         "eslint-visitor-keys": {
@@ -1722,13 +1608,22 @@
             "dev": true
         },
         "espree": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+            "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "^6.0.7",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+                    "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -1886,12 +1781,12 @@
             }
         },
         "external-editor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-            "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
                 "tmp": "^0.0.33"
             }
         },
@@ -1967,9 +1862,9 @@
             "dev": true
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
         "fast-json-stable-stringify": {
@@ -2002,13 +1897,12 @@
             }
         },
         "file-entry-cache": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
             "dev": true,
             "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "flat-cache": "^2.0.1"
             }
         },
         "fill-range": {
@@ -2044,16 +1938,46 @@
             }
         },
         "flat-cache": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "del": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "write": "^0.2.1"
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
             }
+        },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "dev": true
         },
         "for-in": {
             "version": "1.0.2",
@@ -2088,13 +2012,20 @@
             }
         },
         "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "requires": {
-                "graceful-fs": "^4.1.2",
+                "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+                    "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+                }
             }
         },
         "fs.realpath": {
@@ -2706,25 +2637,20 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+            "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
-        },
-        "globby": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -2800,23 +2726,6 @@
                 "function-bind": "^1.1.1"
             }
         },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                }
-            }
-        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2887,15 +2796,36 @@
             }
         },
         "iconv-lite": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
         },
         "ignore": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
+        },
+        "import-fresh": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+            "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
         },
         "import-local": {
             "version": "2.0.0",
@@ -2928,23 +2858,58 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "inquirer": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
-            "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+            "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
                 "cli-cursor": "^2.1.0",
                 "cli-width": "^2.0.0",
-                "external-editor": "^2.1.0",
+                "external-editor": "^3.0.3",
                 "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "lodash": "^4.17.12",
                 "mute-stream": "0.0.7",
                 "run-async": "^2.2.0",
-                "rxjs": "^5.5.2",
+                "rxjs": "^6.4.0",
                 "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
+                "strip-ansi": "^5.1.0",
                 "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+                    "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+                },
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "invariant": {
@@ -3060,6 +3025,12 @@
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3070,6 +3041,15 @@
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
         },
         "is-number": {
             "version": "3.0.0",
@@ -3089,30 +3069,6 @@
                         "is-buffer": "^1.1.5"
                     }
                 }
-            }
-        },
-        "is-path-cwd": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-            "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "^1.0.0"
-            }
-        },
-        "is-path-inside": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -3137,12 +3093,6 @@
             "requires": {
                 "has": "^1.0.1"
             }
-        },
-        "is-resolvable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-            "dev": true
         },
         "is-stream": {
             "version": "1.1.0",
@@ -3860,9 +3810,9 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stable-stringify-without-jsonify": {
@@ -3982,7 +3932,8 @@
         "lodash": {
             "version": "4.17.11",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -4315,12 +4266,6 @@
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4512,6 +4457,15 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
         "parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -4543,12 +4497,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
@@ -4584,27 +4532,6 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
-        "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true
-        },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
-        },
         "pirates": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -4622,12 +4549,6 @@
             "requires": {
                 "find-up": "^3.0.0"
             }
-        },
-        "pluralize": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-            "dev": true
         },
         "pn": {
             "version": "1.1.0",
@@ -4674,9 +4595,9 @@
             "dev": true
         },
         "progress": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
         "promise-polyfill": {
@@ -4788,9 +4709,9 @@
             }
         },
         "regexpp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-            "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
             "dev": true
         },
         "remove-trailing-separator": {
@@ -5123,24 +5044,6 @@
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
-        "require-uncached": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-            "dev": true,
-            "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
-            },
-            "dependencies": {
-                "resolve-from": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-                    "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-                    "dev": true
-                }
-            }
-        },
         "resolve": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
@@ -5209,27 +5112,12 @@
                 "is-promise": "^2.1.0"
             }
         },
-        "rx-lite": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-            "dev": true
-        },
-        "rx-lite-aggregates": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-            "dev": true,
-            "requires": {
-                "rx-lite": "*"
-            }
-        },
         "rxjs": {
-            "version": "5.5.6",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
-            "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
             "requires": {
-                "symbol-observable": "1.0.1"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -5373,11 +5261,13 @@
             "dev": true
         },
         "slice-ansi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
                 "is-fullwidth-code-point": "^2.0.0"
             }
         },
@@ -5674,9 +5564,9 @@
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
             "dev": true
         },
         "supports-color": {
@@ -5687,11 +5577,6 @@
                 "has-flag": "^3.0.0"
             }
         },
-        "symbol-observable": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-        },
         "symbol-tree": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -5699,17 +5584,49 @@
             "dev": true
         },
         "table": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-            "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+            "version": "5.4.5",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+            "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.2.3",
-                "ajv-keywords": "^2.1.0",
-                "chalk": "^2.1.0",
-                "lodash": "^4.17.4",
-                "slice-ansi": "1.0.0",
-                "string-width": "^2.1.1"
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.15",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+                    "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
         },
         "test-exclude": {
@@ -5873,12 +5790,6 @@
                 "prelude-ls": "~1.1.2"
             }
         },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
-        },
         "uglify-js": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -6011,6 +5922,12 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
             "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+            "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
             "dev": true
         },
         "validate-npm-package-license": {
@@ -6167,9 +6084,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
             "dev": true,
             "requires": {
                 "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "license": "ISC",
     "dependencies": {
         "minimist": "^1.2.0",
-        "inquirer": "^5.1.0",
-        "fs-extra": "^7.0.1",
-        "@deg-skeletor/core": "^1.1.0",
-        "@deg-skeletor/orko": "^1.0.0"
+        "inquirer": "^6.5.0",
+        "fs-extra": "^8.1.0",
+        "@deg-skeletor/core": "^1.1.1",
+        "@deg-skeletor/orko": "^1.2.4"
     },
     "devDependencies": {
-        "eslint": "^4.19.1",
+        "eslint": "^6.1.0",
         "jest": "^24.8.0"
     },
     "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/cli",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "The command line interface for Skeletor",
     "repository": "https://github.com/deg-skeletor/skeletor-cli.git",
     "main": "index.js",


### PR DESCRIPTION
Currently, running `skel` with no arguments causes the CLI to run all defined tasks, which isn't ideal in most cases. This change adds the ability to add an `isDefaultTask` property to one config task. Or, if not set, it will just default to the first task in the config's `tasks` array.